### PR TITLE
Fix for app crash on printing entry without password

### DIFF
--- a/kpcli/connector.py
+++ b/kpcli/connector.py
@@ -108,8 +108,19 @@ class KpDatabaseConnector:
         """Retrieve details for a single entry"""
         return {
             "name": f"{entry.group.name}/{entry.title}",
-            "username": entry.username,
-            "password": entry.password if show_password else "*" * len(entry.password),
+            "username": entry.username or "",
+            "password": self._format_password(entry, show_password),
             "URL": entry.url or "",
             "Notes": entry.notes or "",
         }
+
+    def _format_password(self, entry, show_password=False):
+        """
+        Format password for output considering --show_password
+        option and that attribute is nullable.
+        """
+        if entry.password is None:
+            return ""
+        if show_password:
+            return entry.password
+        return "*" * len(entry.password)


### PR DESCRIPTION
- Fixed application crash on printing entry with none-type `password`.
- Empty passwords are displayed correctly now (as empty string, not as "None").
- Added similar mechanism for `username` property.

```
Traceback (most recent call last):
  File ".../bin/kpcli", line 8, in <module>
    sys.exit(app())
  File ".../lib/python3.8/site-packages/typer/main.py", line 214, in __call__
    return get_command(self)(*args, **kwargs)
  File ".../lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File ".../lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File ".../lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File ".../lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File ".../lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File ".../lib/python3.8/site-packages/typer/main.py", line 497, in wrapper
    return callback(**use_params)  # type: ignore
  File ".../lib/python3.8/site-packages/kpcli/cli.py", line 228, in get_entry
    details = ctx_connector(ctx).get_details(entry, show_password)
  File ".../lib/python3.8/site-packages/kpcli/connector.py", line 112, in get_details
    "password": entry.password if show_password else "*" * len(entry.password),
TypeError: object of type 'NoneType' has no len()
```